### PR TITLE
Fix showlangcodes when terminology is missing

### DIFF
--- a/tests/test_showlangcodes.py
+++ b/tests/test_showlangcodes.py
@@ -1,0 +1,25 @@
+import runpy
+import sys
+import types
+from pathlib import Path
+
+
+def test_showlangcodes_uses_bibliographic_when_terminology_missing(
+    monkeypatch, capsys
+):
+    fake_pycountry = types.SimpleNamespace(
+        languages=[
+            types.SimpleNamespace(
+                name='Language without terminology',
+                bibliographic='lwt',
+            )
+        ]
+    )
+    script_path = Path(__file__).resolve().parents[1] / 'wiktionarytodict3.py'
+
+    monkeypatch.setitem(sys.modules, 'pycountry', fake_pycountry)
+    monkeypatch.setattr(sys, 'argv', ['wiktionarytodict3.py', '--showlangcodes'])
+
+    runpy.run_path(script_path, run_name='__main__')
+
+    assert capsys.readouterr().out == 'Language without terminology:lwt\n'

--- a/wiktionarytodict3.py
+++ b/wiktionarytodict3.py
@@ -246,6 +246,14 @@ def usage():
     print("{0} --showlangcodes".format(sys.argv[0]))
     print("example: {0} enwiktionary-test-data-spanish.xml Spanish:spa German:deu ~/Downloads/tempdir".format(sys.argv[0]))
 
+def getLanguageCode(lang):
+    for field in ('alpha_3', 'terminology', 'bibliographic'):
+        try:
+            return getattr(lang, field)
+        except AttributeError:
+            pass
+    return None
+
 if (len(sys.argv) > 4):
     # get the list of languages and language codes that the user specified
     languages = {}
@@ -262,11 +270,9 @@ if (len(sys.argv) > 4):
 elif (len(sys.argv) == 2):
     if sys.argv[1] == '--showlangcodes':
         for lang in list(pycountry.languages):
-            try:
-                terminology = lang.alpha_3
-            except AttributeError:
-                terminology = lang.terminology
-            print("{0}:{1}".format(lang.name, terminology))
+            terminology = getLanguageCode(lang)
+            if terminology is not None:
+                print("{0}:{1}".format(lang.name, terminology))
     else:
         usage()
 else:


### PR DESCRIPTION
## Summary
- add a small language-code helper for `--showlangcodes`
- fall back from `alpha_3` to `terminology`, then `bibliographic` when pycountry language records differ by package/source
- skip records that have no usable language code instead of raising `AttributeError`
- add a regression test with a fake pycountry language record missing `terminology`

Closes #7

## Tests
- `uv run --with pytest pytest tests/test_showlangcodes.py -q`
- `uv run --with pycountry==24.6.1 python wiktionarytodict3.py --showlangcodes >/tmp/wiktionarytodict-showlangcodes.out && wc -l /tmp/wiktionarytodict-showlangcodes.out && head -5 /tmp/wiktionarytodict-showlangcodes.out`
- `uv run --with pytest pytest -q`
- `python3 -m py_compile wiktionarytodict3.py tests/test_showlangcodes.py`

AI assistance was used under my direction.